### PR TITLE
Use distinct data dirs for each signet

### DIFF
--- a/src/common/args.cpp
+++ b/src/common/args.cpp
@@ -5,6 +5,7 @@
 
 #include <common/args.h>
 
+#include <hash.h>
 #include <chainparamsbase.h>
 #include <common/settings.h>
 #include <logging.h>
@@ -277,6 +278,18 @@ fs::path ArgsManager::GetPathArg(std::string arg, const fs::path& default_value)
     return result.has_filename() ? result : result.parent_path();
 }
 
+fs::path ArgsManager::GetSignetDataDir() const
+{
+    const std::string base_data_dir = BaseParams().DataDir();
+    const std::string signet_challenge_str = GetArg("-signetchallenge", "");
+    if (!signet_challenge_str.empty()) {
+        std::vector<uint8_t> signet_challenge = ParseHex(signet_challenge_str);
+        const auto hash_160 = Hash160(signet_challenge);
+        return fs::PathFromString(base_data_dir + "-" + HexStr(hash_160));
+    }
+    return fs::PathFromString(base_data_dir);
+}
+
 fs::path ArgsManager::GetBlocksDirPath() const
 {
     LOCK(cs_args);
@@ -296,7 +309,12 @@ fs::path ArgsManager::GetBlocksDirPath() const
         path = GetDataDirBase();
     }
 
-    path /= fs::PathFromString(BaseParams().DataDir());
+    if (GetChainType() == ChainType::SIGNET) {
+        path /= GetSignetDataDir();
+    } else {
+        path /= fs::PathFromString(BaseParams().DataDir());
+    }
+
     path /= "blocks";
     fs::create_directories(path);
     return path;
@@ -322,7 +340,11 @@ fs::path ArgsManager::GetDataDir(bool net_specific) const
     }
 
     if (net_specific && !BaseParams().DataDir().empty()) {
-        path /= fs::PathFromString(BaseParams().DataDir());
+        if (GetChainType() == ChainType::SIGNET) {
+            path /= GetSignetDataDir();
+        } else {
+            path /= fs::PathFromString(BaseParams().DataDir());
+        }
     }
 
     return path;

--- a/src/common/args.h
+++ b/src/common/args.h
@@ -211,6 +211,14 @@ protected:
     std::optional<const Command> GetCommand() const;
 
     /**
+     * Get signet data directory path.
+     * If a signet-challange argument is provided, it is used in constructing the directory path.
+     *
+     * @return The path to the signet data directory.
+    */
+    fs::path GetSignetDataDir() const;
+
+    /**
      * Get blocks directory path
      *
      * @return Blocks path which is network specific


### PR DESCRIPTION
If the -signetchallenge argument is provided,
the hash-160 of the challenge is appended to the datadir name, resulting in unique data directories for each signet, i.e., signet-XXXXXXX.

<!--
*** Please remove the following help text before submitting: ***

Pull requests without a rationale and clear improvement may be closed
immediately.

GUI-related pull requests should be opened against
https://github.com/bitcoin-core/gui
first. See CONTRIBUTING.md
-->

<!--
Please provide clear motivation for your patch and explain how it improves
Bitcoin Core user experience or Bitcoin Core developer experience
significantly:

* Any test improvements or new tests that improve coverage are always welcome.
* All other changes should have accompanying unit tests (see `src/test/`) or
  functional tests (see `test/`). Contributors should note which tests cover
  modified code. If no tests exist for a region of modified code, new tests
  should accompany the change.
* Bug fixes are most welcome when they come with steps to reproduce or an
  explanation of the potential issue as well as reasoning for the way the bug
  was fixed.
* Features are welcome, but might be rejected due to design or scope issues.
  If a feature is based on a lot of dependencies, contributors should first
  consider building the system outside of Bitcoin Core, if possible.
* Refactoring changes are only accepted if they are required for a feature or
  bug fix or otherwise improve developer experience significantly. For example,
  most "code style" refactoring changes require a thorough explanation why they
  are useful, what downsides they have and why they *significantly* improve
  developer experience or avoid serious programming bugs. Note that code style
  is often a subjective matter. Unless they are explicitly mentioned to be
  preferred in the [developer notes](/doc/developer-notes.md), stylistic code
  changes are usually rejected.
-->

<!--
Bitcoin Core has a thorough review process and even the most trivial change
needs to pass a lot of eyes and requires non-zero or even substantial time
effort to review. There is a huge lack of active reviewers on the project, so
patches often sit for a long time.
-->
